### PR TITLE
feat(#53): Supprimer la partie frais kilométriques

### DIFF
--- a/src/api/makeup-artiste/content-types/makeup-artiste/schema.json
+++ b/src/api/makeup-artiste/content-types/makeup-artiste/schema.json
@@ -34,9 +34,6 @@
     "score": {
       "type": "decimal"
     },
-    "mileage_charge": {
-      "type": "decimal"
-    },
     "available": {
       "type": "boolean"
     },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-04-29T14:15:00.593Z"
+    "x-generation-date": "2023-04-30T11:01:33.329Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -104,10 +104,6 @@
                 "type": "integer"
               },
               "score": {
-                "type": "number",
-                "format": "float"
-              },
-              "mileage_charge": {
                 "type": "number",
                 "format": "float"
               },
@@ -255,10 +251,6 @@
             "type": "integer"
           },
           "score": {
-            "type": "number",
-            "format": "float"
-          },
-          "mileage_charge": {
             "type": "number",
             "format": "float"
           },
@@ -762,10 +754,6 @@
                                     "type": "integer"
                                   },
                                   "score": {
-                                    "type": "number",
-                                    "format": "float"
-                                  },
-                                  "mileage_charge": {
                                     "type": "number",
                                     "format": "float"
                                   },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-04-30T11:01:33.329Z"
+    "x-generation-date": "2023-04-30T11:04:31.807Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
en vrai ça sert plus à rien, on s'en servira pas à cours terme, et l'info peut être mise dans les prestations, souvent les frais kilométriques sont indiquées là dedans plutôt ! 