### PR TITLE
fix(#58): 🐛 ajouter la fonctionnalité de population des relations dans la requête de recherche

### DIFF
--- a/src/api/makeup-artiste/services/init-makeup.js
+++ b/src/api/makeup-artiste/services/init-makeup.js
@@ -102,7 +102,23 @@ module.exports = {
     const existing = await strapi.entityService.findMany(
       "api::makeup-artiste.makeup-artiste",
       {
-        populate: "*",
+        populate: {
+          skills: {
+            populate: "*",
+          },
+          experiences: {
+            populate: "*",
+          },
+          courses: {
+            populate: "*",
+          },
+          service_offers: {
+            populate: "*",
+          },
+          network: {
+            populate: "*",
+          },
+        },
         filters: {
           user: {
             id: {

--- a/src/api/searching/services/searching.js
+++ b/src/api/searching/services/searching.js
@@ -29,10 +29,10 @@ const balancedKeys = [
       makeupArtiste.service_offers.map((service) => service.description),
   },
   {
-    name: "service_offers_Option_description",
+    name: "service_offers_option_description",
     weight: 1.2,
     getFn: (makeupArtiste) =>
-      makeupArtiste.service_offers.map((Option) => Option.description),
+      makeupArtiste.service_offers.map((option) => option.description),
   },
   {
     name: "courses_course_description",
@@ -93,7 +93,7 @@ module.exports = {
         skills_description: params.search ?? "",
         description: params.search ?? "",
         service_offers_description: params.search ?? "",
-        service_offers_Option_description: params.search ?? "",
+        service_offers_option_description: params.search ?? "",
         courses_course_description: params.search ?? "",
         experiences_description: params.search ?? "",
         last_name: params.search ?? "",

--- a/src/components/makeupartists/service-offers.json
+++ b/src/components/makeupartists/service-offers.json
@@ -12,7 +12,7 @@
     "description": {
       "type": "text"
     },
-    "Options": {
+    "options": {
       "displayName": "options",
       "type": "component",
       "repeatable": true,

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-04-30T12:59:10.194Z"
+    "x-generation-date": "2023-04-30T19:49:00.877Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -892,7 +892,7 @@
                                         "description": {
                                           "type": "string"
                                         },
-                                        "Options": {
+                                        "options": {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
@@ -2015,7 +2015,7 @@
           "description": {
             "type": "string"
           },
-          "Options": {
+          "options": {
             "type": "array",
             "items": {
               "type": "object",


### PR DESCRIPTION
✨ fonctionnalité(init-makeup.js) : ajouter la fonctionnalité de population des relations dans la requête de recherche La clé connect ne doit pas contenir d'espaces inutiles pour éviter les erreurs. La fonctionnalité de population des relations permet de récupérer toutes les données liées à la recherche, ce qui améliore la qualité des résultats de recherche.

🐛 corriger(searching.js) : corriger le nom de la clé service_offers_option_description Le nom de la clé service_offers_option_description a été corrigé pour correspondre à la convention de nommage.

🐛 corriger(service-offers.json) : corriger le nom de la clé options Le nom de la clé options a été corrigé pour correspondre