### PR TITLE
fix(#64): 🐛 mettre à jour les données de mise à jour du maquilleur

### DIFF
--- a/src/api/makeup-artiste/services/init-makeup.js
+++ b/src/api/makeup-artiste/services/init-makeup.js
@@ -63,33 +63,20 @@ module.exports = {
       throw new Error("Makeup artist does not exist for this user");
     }
 
-    // Prepare update data
-    const updateData = {
-      speciality: json.speciality,
-      city: json.city,
-      action_radius: json.action_radius,
-      score: json.score,
-      mileage_charge: json.mileage_charge,
-      available: json.available,
-      description: json.description,
-      last_name: json.last_name,
-      first_name: json.first_name,
-      skills: json.skills,
-      network: json.network,
-      experiences: json.experiences,
-      courses: json.courses,
-      service_offers: json.service_offers,
-      image_gallery: json.image_gallery,
-      main_picture: json.main_picture,
-      language: json.language,
-    };
-
     // update the makeup artist linked to user
-    return strapi.entityService.update(
+    let updated = await strapi.entityService.update(
       "api::makeup-artiste.makeup-artiste",
       existing[0].id, // id of makeup artist linked to user
       {
-        data: updateData,
+        data: json,
+      }
+    );
+
+    return strapi.entityService.findOne(
+      "api::makeup-artiste.makeup-artiste",
+      updated.id,
+      {
+        populate: "*",
       }
     );
   },
@@ -103,7 +90,7 @@ module.exports = {
       "api::makeup-artiste.makeup-artiste",
       {
         populate: {
-          main_picture:{
+          main_picture: {
             populate: "*",
           },
           skills: {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-05-01T11:19:55.251Z"
+    "x-generation-date": "2023-05-06T17:41:51.442Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
✨ fonctionnalité(init-makeup.js) : ajouter la fonctionnalité de population pour les requêtes de maquilleur La mise à jour des données du maquilleur a été corrigée pour utiliser les données JSON fournies plutôt que de les définir manuellement. La fonctionnalité de population a été ajoutée pour les requêtes de maquilleur pour inclure toutes les données associées telles que les images, les compétences, les expériences, etc.