### PR TITLE
fix(#69): 🚀 ajouter des filtres pour les images, la langue et la galerie d'images

### DIFF
--- a/src/api/searching/services/searching.js
+++ b/src/api/searching/services/searching.js
@@ -71,6 +71,9 @@ module.exports = {
             "courses",
             "service_offers",
             "network",
+            "image_gallery",
+            "main_picture",
+            "language",
           ],
           filters: {
             available: {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-05-07T17:34:57.027Z"
+    "x-generation-date": "2023-05-08T17:40:25.947Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
fix(#69): 🚀 ajouter des filtres pour les images, la langue et la galerie d'images

🚀 fonctionnalité(full_documentation.json) : mettre à jour la date de génération de la documentation Les filtres pour les images, la langue et la galerie d'images ont été ajoutés pour améliorer la recherche. La date de génération de la documentation a été mise à jour pour refléter la dernière version de la documentation.