### PR TITLE
fix(#74): 🔧  ajouter des valeurs par défaut pour les champs spécialité, description et réseau

### DIFF
--- a/src/api/makeup-artiste/content-types/makeup-artiste/schema.json
+++ b/src/api/makeup-artiste/content-types/makeup-artiste/schema.json
@@ -23,7 +23,8 @@
       "minLength": 3
     },
     "speciality": {
-      "type": "string"
+      "type": "string",
+      "default": ""
     },
     "city": {
       "type": "string"
@@ -44,13 +45,15 @@
       "component": "makeupartists.skills"
     },
     "description": {
-      "type": "text"
+      "type": "text",
+      "default": ""
     },
     "network": {
       "displayName": "network",
       "type": "component",
       "repeatable": false,
-      "component": "makeupartists.network"
+      "component": "makeupartists.network",
+      "default": {}
     },
     "user": {
       "type": "relation",

--- a/src/api/makeup-artiste/services/me-makeup.js
+++ b/src/api/makeup-artiste/services/me-makeup.js
@@ -36,6 +36,12 @@ module.exports = {
         user: {
           connect: [{ id: user.id }],
         },
+        first_name: "",
+        last_name: "",
+        speciality: "",
+        city: "",
+        network: {},
+        description: "",
       },
     });
   },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-05-08T17:40:25.947Z"
+    "x-generation-date": "2023-05-29T18:42:31.356Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -25,7 +25,7 @@
   },
   "servers": [
     {
-      "url": "http://0.0.0.0:1337/api",
+      "url": "http://localhost:1337/api",
       "description": "Development server"
     }
   ],


### PR DESCRIPTION
fix(#74): 🔧  ajouter des valeurs par défaut pour les champs spécialité, description et réseau

🔧 corriger(me-makeup.js) : ajouter des valeurs par défaut pour les champs first_name, last_name, spécialité, ville, réseau et description 🔧 corriger(full_documentation.json) : mettre à jour la date de génération Les valeurs par défaut ont été ajoutées pour les champs spécialité, description et réseau dans le fichier schema.json et pour les champs first_name, last_name, spécialité, ville, réseau et description dans le fichier me-makeup.js. Cela permettra d'éviter les erreurs lors de la création d'un nouvel utilisateur. La date de génération a été mise à jour dans le fichier full_documentation.json pour refléter la dernière mise à jour de la documentation.