### PR TITLE
fix(#80):🔥supprimer les champs first_name et last_name

### DIFF
--- a/src/api/makeup-artiste/services/me-makeup.js
+++ b/src/api/makeup-artiste/services/me-makeup.js
@@ -36,8 +36,6 @@ module.exports = {
         user: {
           connect: [{ id: user.id }],
         },
-        first_name: "",
-        last_name: "",
         speciality: "",
         city: "",
         network: {},

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-06-08T12:37:26.733Z"
+    "x-generation-date": "2023-06-10T23:02:03.363Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
🔖 docs(full_documentation.json) : mettre à jour la date de génération de la documentation Les champs first_name et last_name ont été supprimés car ils ne sont plus nécessaires. La date de génération de la documentation a été mise à jour pour refléter la dernière version de la documentation.