### PR TITLE
feat(#85): ✨ ajouter le champ username

### DIFF
--- a/src/api/makeup-artiste/content-types/makeup-artiste/schema.json
+++ b/src/api/makeup-artiste/content-types/makeup-artiste/schema.json
@@ -23,8 +23,7 @@
       "minLength": 3
     },
     "speciality": {
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "city": {
       "type": "string"
@@ -45,8 +44,7 @@
       "component": "makeupartists.skills"
     },
     "description": {
-      "type": "text",
-      "default": ""
+      "type": "text"
     },
     "network": {
       "displayName": "network",
@@ -100,6 +98,9 @@
       "type": "component",
       "repeatable": true,
       "component": "makeupartists.language"
+    },
+    "username": {
+      "type": "string"
     }
   }
 }

--- a/src/api/makeup-artiste/services/me-makeup.js
+++ b/src/api/makeup-artiste/services/me-makeup.js
@@ -40,6 +40,7 @@ module.exports = {
         city: "",
         network: {},
         description: "",
+        username: user.username,
       },
     });
   },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-06-14T09:05:52.245Z"
+    "x-generation-date": "2023-06-14T13:52:44.172Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -25,7 +25,7 @@
   },
   "servers": [
     {
-      "url": "http://0.0.0.0:1337/api",
+      "url": "http://localhost:1337/api",
       "description": "Development server"
     }
   ],
@@ -1016,6 +1016,9 @@
                 "items": {
                   "$ref": "#/components/schemas/MakeupartistsLanguageComponent"
                 }
+              },
+              "username": {
+                "type": "string"
               }
             }
           }
@@ -2282,6 +2285,9 @@
                                       }
                                     }
                                   },
+                                  "username": {
+                                    "type": "string"
+                                  },
                                   "createdAt": {
                                     "type": "string",
                                     "format": "date-time"
@@ -2682,6 +2688,9 @@
             "items": {
               "$ref": "#/components/schemas/MakeupartistsLanguageComponent"
             }
+          },
+          "username": {
+            "type": "string"
           },
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
✨ fonctionnalité(me-makeup.js) : ajouter le champ username lors de la création d'un nouvel artiste de maquillage ✨ fonctionnalité(full_documentation.json) : ajouter le champ username dans la documentation de l'API makeup-artiste Les valeurs par défaut pour les champs speciality et description ont été supprimées car elles ne sont pas nécessaires et peuvent causer des erreurs si elles sont laissées vides. Le champ username a été ajouté lors de la création d'un nouvel artiste de maquillage pour stocker le nom d'utilisateur de l'utilisateur qui a créé l'artiste. Le champ username a également été ajouté à la documentation de l'API makeup-artiste pour refléter cette modification.